### PR TITLE
Allow filtering bug fix

### DIFF
--- a/core/src/main/scala/spinoco/fs2/cassandra/builder/QueryBuilder.scala
+++ b/core/src/main/scala/spinoco/fs2/cassandra/builder/QueryBuilder.scala
@@ -251,7 +251,7 @@ case class QueryBuilder[R <: HList, PK <: HList, CK <: HList, IDX <: HList, Q <:
 
 
     val allowFilteringStmt =
-      if (allowFilteringFlag) "WITH ALLOW FILTERING" else ""
+      if (allowFilteringFlag) "ALLOW FILTERING" else ""
 
     val limitStmt = limitCount.map(c => s"LIMIT $c").mkString
 

--- a/test/src/test/scala/spinoco/fs2/cassandra/builder/QueryBuilderSpec.scala
+++ b/test/src/test/scala/spinoco/fs2/cassandra/builder/QueryBuilderSpec.scala
@@ -198,7 +198,7 @@ class QueryBuilderSpec extends Fs2CassandraSpec {
         .build
         .cqlStatement shouldBe
         "SELECT stringColumn" +
-          " FROM test_ks.test_table WITH ALLOW FILTERING"
+          " FROM test_ks.test_table ALLOW FILTERING"
     }
 
 


### PR DESCRIPTION
As reported on the [Gitter channel](https://gitter.im/fs2-cassandra/Lobby?at=5bbc43e73844923661091772) the generated CQL query when using `allowFiltering` is incorrect. 

This PR fixes it.